### PR TITLE
alertreducer small edit

### DIFF
--- a/client/src/reducers/alertReducer.js
+++ b/client/src/reducers/alertReducer.js
@@ -1,6 +1,6 @@
 import { alertConstants } from "../constants/alertConstants";
 
-export function alertReducer(state = {}, action) {
+export function alert(state = {}, action) {
   switch (action.type) {
     case alertConstants.SUCCESS:
       return {

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,10 +1,10 @@
 import { combineReducers } from 'redux';
-import { alertReducer } from './alertReducer';
+import { alert } from './alertReducer';
 //import all reducers here
 
 const rootReducer = combineReducers({
 //add all new reducers here
-    alertReducer,
+    alert,
 })
 
 export default rootReducer;


### PR DESCRIPTION
double check that this still works on your end, I changed the reducer function name back to alert but fixed how it is imported in the index reducer. It doesn't matter a whole lot either way, but in terms of variable names it is good when the reducer functions are named by what they do (like alert, saveProfile, authenticate, etc) 